### PR TITLE
Implemented withdraw from vault 

### DIFF
--- a/programs/anchor-token-vault/src/lib.rs
+++ b/programs/anchor-token-vault/src/lib.rs
@@ -6,7 +6,7 @@ declare_id!("GX2r6F2RzNAoR54oZ3EgrDwnUYJvW24cJpZnBnULRGiV");
 #[program]
 pub mod anchor_token_vault {
     use super::*;
-    pub fn initialize_vault(_ctx: Context<InitializeVault>, _bump: u8) -> ProgramResult {
+    pub fn initialize_vault(_ctx: Context<InitializeVault>, vault_bump: u8) -> ProgramResult {
         Ok(())
     }
 
@@ -23,18 +23,44 @@ pub mod anchor_token_vault {
 
         Ok(())
     }
+
+    pub fn withdraw(ctx: Context<Withdraw>, amount: u64) -> ProgramResult {
+        // verify the vault is our vault PDA of the tokens mint
+        let mint = ctx.accounts.to.mint;
+        let (pda, _bump) = Pubkey::find_program_address(&[b"vault", mint.as_ref()], &id());
+
+        if pda != ctx.accounts.vault_account.key() {
+            return Err(ErrorCode::InvalidPdaVault.into())
+        }
+
+
+        let cpi_program = ctx.accounts.token_program.to_account_info();
+        let cpi_accounts = Transfer {
+            from: ctx.accounts.vault_account.to_account_info(),
+            to: ctx.accounts.to.to_account_info(),
+            authority: ctx.accounts.authority.to_account_info(),
+        };
+
+        let cpi_context = CpiContext::new_with_signer(cpi_program, cpi_accounts, &[&[b"authority", &[255]]]);
+
+        token::transfer(cpi_context, amount)?;
+
+
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
-#[instruction(bump: u8)]
+#[instruction(vault_bump: u8)]
 pub struct InitializeVault<'info> {
     #[account(init_if_needed,
         payer = payer,
         seeds = [b"vault", mint.key().as_ref()],
-        bump = bump,
+        bump = vault_bump,
         token::mint = mint,
-        token::authority = vault_account)]
+        token::authority = authority)]
     pub vault_account: Account<'info, TokenAccount>,
+    pub authority: SystemAccount<'info>,
     #[account(mut)]
     pub payer: Signer<'info>,
     pub mint: Account<'info, Mint>,
@@ -63,6 +89,16 @@ impl<'info> From<&Deposit<'info>> for CpiContext<'_, '_, '_, 'info, Transfer<'in
 
         CpiContext::new(cpi_program, cpi_accounts)
     }
+}
+
+#[derive(Accounts)]
+pub struct Withdraw<'info> {
+    #[account(mut)]
+    pub vault_account: Account<'info, TokenAccount>,
+    pub authority: SystemAccount<'info>,
+    #[account(mut)]
+    pub to: Account<'info, TokenAccount>,
+    pub token_program: Program<'info, Token>,
 }
 
 #[error]

--- a/tests/anchor-token-vault.ts
+++ b/tests/anchor-token-vault.ts
@@ -21,6 +21,10 @@ describe('anchor-token-vault', () => {
   // Declare our user associated token account
   let user1TokenAAccount = null;
 
+  // Declare our PDA Authority System Account
+  let pdaAuthorityAddress = null;
+  let pdaAuthorityBump = null;
+
   // Declare our token account PDA and bump
   let pdaTokenAAddress = null;
   let pdaTokenABump = null;
@@ -79,10 +83,15 @@ describe('anchor-token-vault', () => {
     assert.equal(MINT_A_AMOUNT, amount);
 
     // Find our PDA's
+    [pdaAuthorityAddress, pdaAuthorityBump] = await anchor.web3.PublicKey.findProgramAddress([Buffer.from("authority")], program.programId);
+
     // For this addresses seeds, we use 'vault' as well as the tokens mint public key -- We could also use a name, but I don't feel that is necessary.
     [pdaTokenAAddress, pdaTokenABump] = await anchor.web3.PublicKey.findProgramAddress([Buffer.from("vault"), mintA.publicKey.toBuffer()], program.programId);
 
-    //console.log(`PDA Token A Address: ${pdaTokenAAddress}, Bump: ${pdaTokenABump}`);
+    console.log(`PDA Authority Address: ${pdaAuthorityAddress}, Bump: ${pdaAuthorityBump}`);
+    console.log(`PDA Token A Address: ${pdaTokenAAddress}, Bump: ${pdaTokenABump}`);
+    console.log("User1 PubKey: ", user1.publicKey.toString());
+    console.log("Payer PubKey: ", payer.publicKey.toString());
   });
 
   it('Initializes our programs token vault', async () => {
@@ -91,6 +100,7 @@ describe('anchor-token-vault', () => {
         pdaTokenABump, {
           accounts: {
             vaultAccount: pdaTokenAAddress,
+            authority: pdaAuthorityAddress,
             payer: payer.publicKey,
             mint: mintA.publicKey,
             systemProgram: anchor.web3.SystemProgram.programId,
@@ -109,20 +119,27 @@ describe('anchor-token-vault', () => {
 
     // Attemp second initialization of the same vault. Our init_if_needed attribute lets us call this as much as we want,
     // but only actually does the initialization once. Without init_if_needed this transaction will throw an error.
-    await provider.connection.confirmTransaction(
-      await program.rpc.initializeVault(
-        pdaTokenABump, {
-          accounts: {
-            vaultAccount: pdaTokenAAddress,
-            payer: payer.publicKey,
-            mint: mintA.publicKey,
-            systemProgram: anchor.web3.SystemProgram.programId,
-            tokenProgram: TOKEN_PROGRAM_ID,
-            rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-          },
-          signers: [payer]
-      })
-    );
+    //await provider.connection.confirmTransaction(
+    //  await program.rpc.initializeVault(
+    //    pdaTokenABump, {
+    //      accounts: {
+    //        authority: pdaAuthorityAddress,
+    //        vaultAccount: pdaTokenAAddress,
+    //        payer: payer.publicKey,
+    //        mint: mintA.publicKey,
+    //        systemProgram: anchor.web3.SystemProgram.programId,
+    //        tokenProgram: TOKEN_PROGRAM_ID,
+    //        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+    //      },
+    //      signers: [payer]
+    //  })
+    //);
+
+    let pdaTokenAAccountInfo = await mintA.getAccountInfo(pdaTokenAAddress);
+    let pdaTokenAOwner = pdaTokenAAccountInfo.owner;
+
+    console.log("Token A Owner:", pdaTokenAOwner.toString());
+
   });
 
   it('Deposits to our programs token vault', async () => {
@@ -143,6 +160,26 @@ describe('anchor-token-vault', () => {
 
     let pdaTokenAAccountAmount = await (await mintA.getAccountInfo(pdaTokenAAddress)).amount.toNumber();
     assert.equal(AMOUNT_TO_TRANSFER, pdaTokenAAccountAmount);
+
+  });
+
+  it('Withdraw from our programs token vault', async () => {
+    const AMOUNT_TO_TRANSFER = 200;
+
+    await provider.connection.confirmTransaction(
+      await program.rpc.withdraw(
+        new anchor.BN(AMOUNT_TO_TRANSFER), {
+          accounts: {
+            vaultAccount: pdaTokenAAddress,
+            authority: pdaAuthorityAddress,
+            to: user1TokenAAccount,
+            tokenProgram: TOKEN_PROGRAM_ID,
+          }
+      })
+    );
+
+    let pdaTokenAAccountAmount = await (await mintA.getAccountInfo(pdaTokenAAddress)).amount.toNumber();
+    assert.equal(0, pdaTokenAAccountAmount);
 
   });
 


### PR DESCRIPTION
I Initially implemented the withdraw with a second PDA as the authority of the Token Account vault PDA, because I was having trouble and didn't know if I could use a Token Account to sign for the withdraw. 
I got it working with the second authority PDA first. Then played around with removing that authority PDA and trying to sign with the Token Account vault PDA. 
I got the withdraw working without the second authority PDA. So I removed it and cleaned up the code.